### PR TITLE
Change name to @cycle/history, bump to v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "cycle-history",
-  "version": "0.5.0",
+  "name": "@cycle/history",
+  "version": "1.0.0",
   "description": "Cycle.js Driver based on the rackt/history library",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
This package will now be included in the @cycle namespace.

Bumping to v1.0.0. Going to maintain backwards compatibility now that more eyes will be on this package.